### PR TITLE
chore: remove unsused folder

### DIFF
--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -1,3 +1,0 @@
-{
-   "signedContributors": []
-}


### PR DESCRIPTION
We've moved the CLA signatures to a dedicated private project. Therefore, we don't need this folder anymore.